### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore Ansible collection package files
+*.tar.gz


### PR DESCRIPTION
Adds a .gitignore file to ignore Ansible collection package files from being tracked.